### PR TITLE
fix: assign isSettling = false

### DIFF
--- a/contracts/earn/WooSuperChargerVaultV2.sol
+++ b/contracts/earn/WooSuperChargerVaultV2.sol
@@ -479,7 +479,7 @@ contract WooSuperChargerVaultV2 is ERC20, Ownable, Pausable, ReentrancyGuard {
 
         if (requestUsers.length() == 0) {
             // NOTE: all settling finished
-            isSettling == false;
+            isSettling = false;
 
             instantWithdrawnAmount = 0;
             lendingManager.accureInterest();


### PR DESCRIPTION
## Summary

Fixes a typo where `isSettling == false;` was used instead of `isSettling = false;`. The `==` operator performs an equality comparison and discards the result, so the statement is a no-op, so the `isSettling` flag is never actually reset.

## Impact

Because `isSettling` is never cleared, it remains `true` after the operation completes. Any logic gated on `isSettling` stays blocked / stuck in the settling state.

This is reachable only through an admin-only function, so it is not externally exploitable and there is no direct path for an attacker to trigger it. The practical risk is an operational issue: the protocol can end up wedged in the settling state, requiring further admin intervention to recover.